### PR TITLE
fix: code block invalid encoding

### DIFF
--- a/editormd.js
+++ b/editormd.js
@@ -3818,6 +3818,7 @@
         }
 
         try {
+            html = encodeURI(html)
             html = decodeURI(html)
         } catch (error) {
             return "Invalid encoding detected"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ibm-skills-network/editor.md",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Open source online markdown editor.",
   "directories": {
     "doc": "docs",

--- a/src/editormd.js
+++ b/src/editormd.js
@@ -3806,6 +3806,7 @@
         }
 
         try {
+            html = encodeURI(html)
             html = decodeURI(html)
         } catch (error) {
             return "Invalid encoding detected"


### PR DESCRIPTION
Fixes invalid encoding error caused by putting a `%` in a code block. 

Call `encodeURI(html)` first to encode `%` character--this will replace the % character with an escape sequence representing the UTF-8 encoding of the character. Then, go ahead and decode it.

Also tested with XSS vulnerabilities and all vulnerabilities remain fixed.

Result tested locally: 
<img width="254" alt="Screen Shot 2021-11-12 at 11 02 48 AM" src="https://user-images.githubusercontent.com/76456096/141496928-4405da96-57e4-49b5-8a8b-c8a4f837fe71.png">
